### PR TITLE
Improved JWT Check Feedback

### DIFF
--- a/src/app/controllers/JWTSuiteTabController.java
+++ b/src/app/controllers/JWTSuiteTabController.java
@@ -11,7 +11,9 @@ import javax.swing.event.DocumentListener;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.exceptions.InvalidClaimException;
 import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 
 import app.algorithm.AlgorithmLinker;
@@ -119,8 +121,18 @@ public class JWTSuiteTabController extends Observable implements ITab {
 		} catch (JWTVerificationException e) {
 			ConsoleOut.output("Verification failed (" + e.getMessage() + ")");
 			jwtSTM.setVerificationResult(e.getMessage());
-			jwtSTM.setJwtSignatureColor(Settings.colorInvalid);
-			jwtSTM.setVerificationLabel(Strings.verificationWrongKey);
+
+			if (e instanceof SignatureVerificationException) {
+				jwtSTM.setJwtSignatureColor(Settings.colorInvalid);
+				jwtSTM.setVerificationLabel(Strings.verificationInvalidSignature);
+			} else if(e instanceof InvalidClaimException) {
+				jwtSTM.setJwtSignatureColor(Settings.colorProblemInvalid);
+				jwtSTM.setVerificationLabel(Strings.verificationInvalidClaim);
+			}else {
+				jwtSTM.setJwtSignatureColor(Settings.colorProblemInvalid);
+				jwtSTM.setVerificationLabel(Strings.verificationError);
+			}
+
 		} catch (IllegalArgumentException | UnsupportedEncodingException e) {
 			ConsoleOut.output("Verification failed (" + e.getMessage() + ")");
 			jwtSTM.setJwtSignatureColor(Settings.colorProblemInvalid);

--- a/src/app/controllers/JWTTabController.java
+++ b/src/app/controllers/JWTTabController.java
@@ -10,7 +10,9 @@ import javax.swing.event.DocumentListener;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.exceptions.InvalidClaimException;
 import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.exceptions.SignatureVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 
 import app.algorithm.AlgorithmLinker;
@@ -125,9 +127,16 @@ public class JWTTabController implements IMessageEditorTab {
 			test.getAlgorithm();
 			jwtVT.updateSetView(algoType);
 		} catch (JWTVerificationException e) {
-			//ConsoleOut.output("Verification failed (" + e.getMessage() + ")");
-			jwtTM.setVerificationLabel(Strings.verificationWrongKey);
-			jwtTM.setVerificationColor(Settings.colorInvalid);
+			if (e instanceof SignatureVerificationException) {
+				jwtTM.setVerificationColor(Settings.colorInvalid);
+				jwtTM.setVerificationLabel(Strings.verificationInvalidSignature);
+			} else if(e instanceof InvalidClaimException) {
+				jwtTM.setVerificationColor(Settings.colorProblemInvalid);
+				jwtTM.setVerificationLabel(Strings.verificationInvalidClaim);
+			}else {
+				jwtTM.setVerificationColor(Settings.colorProblemInvalid);
+				jwtTM.setVerificationLabel(Strings.verificationError);
+			}
 			jwtTM.setVerificationResult(e.getMessage());
 			jwtVT.updateSetView(algoType);
 		} catch (IllegalArgumentException | UnsupportedEncodingException e) {

--- a/src/app/helpers/Strings.java
+++ b/src/app/helpers/Strings.java
@@ -18,8 +18,10 @@ public class Strings {
 	public static final String enterJWT = "Enter JWT";
 	
 	public static final String verificationValid = "Signature verified";
-	public static final String verificationInvalidKey = "Invalid key";
-	public static final String verificationWrongKey = "Invalid Signature / wrong key / claim failed";
+	public static final String verificationInvalidKey = "Invalid Key";
+	public static String verificationInvalidSignature = "Cannot verify Signature";
+	public static String verificationInvalidClaim = "Not all Claims accepted";
+	public static final String verificationError = "Invalid Signature / wrong key / claim failed";
 
 	public static final String interceptRecalculationKey = "Secret / Key for Signature recalculation:";
 
@@ -76,7 +78,7 @@ public class Strings {
 									+"YqWZhkyQ8C05tDyGvDI5b7bVmD1pxmnhG9sOktrkDVkOsYUnAhRwCgmuExkoeGWP"
 									+"vUt+85cmMpJfHHqbrb5FLqTeXQ==";
 
-	
+
 	public static String filePathToString(String filePath) {
 		StringBuilder contentBuilder = new StringBuilder();
 		try (BufferedReader br = new BufferedReader(new FileReader(filePath))) {

--- a/src/app/tokenposition/AuthorizationBearerHeader.java
+++ b/src/app/tokenposition/AuthorizationBearerHeader.java
@@ -27,10 +27,8 @@ public class AuthorizationBearerHeader extends ITokenPosition {
 	}
 	
 	private boolean headerContainsaKeyWordAndIsJWT(String header, List<String> jwtKeywords) {
-		header = header.toLowerCase();
 		for(String keyword : jwtKeywords){
-			keyword = keyword.toLowerCase();
-			if(header.startsWith(keyword)){ 
+			if(header.toLowerCase().startsWith(keyword.toLowerCase())){ 
 				String jwt = header.replace(keyword, "").trim();
 				if(CustomJWToken.isValidJWT(jwt)){
 					this.selectedKeyword = keyword;

--- a/src/app/tokenposition/AuthorizationBearerHeader.java
+++ b/src/app/tokenposition/AuthorizationBearerHeader.java
@@ -27,7 +27,9 @@ public class AuthorizationBearerHeader extends ITokenPosition {
 	}
 	
 	private boolean headerContainsaKeyWordAndIsJWT(String header, List<String> jwtKeywords) {
+		header = header.toLowerCase();
 		for(String keyword : jwtKeywords){
+			keyword = keyword.toLowerCase();
 			if(header.startsWith(keyword)){ 
 				String jwt = header.replace(keyword, "").trim();
 				if(CustomJWToken.isValidJWT(jwt)){

--- a/src/app/tokenposition/AuthorizationBearerHeader.java
+++ b/src/app/tokenposition/AuthorizationBearerHeader.java
@@ -7,7 +7,7 @@ import app.helpers.CustomJWToken;
 
 public class AuthorizationBearerHeader extends ITokenPosition {
 
-	private static List<String> jwtKeywords = Arrays.asList("Authorization: Bearer");
+	private static List<String> jwtKeywords = Arrays.asList("Authorization: Bearer", "Authorization: bearer", "authorization: Bearer", "authorization: bearer");
 	private String selectedKeyword;
 	private Integer headerIndex;
 	private List<String> headers;

--- a/src/app/tokenposition/AuthorizationBearerHeader.java
+++ b/src/app/tokenposition/AuthorizationBearerHeader.java
@@ -28,7 +28,7 @@ public class AuthorizationBearerHeader extends ITokenPosition {
 	
 	private boolean headerContainsaKeyWordAndIsJWT(String header, List<String> jwtKeywords) {
 		for(String keyword : jwtKeywords){
-			if(header.toLowerCase().startsWith(keyword.toLowerCase())){ 
+			if(header.startsWith(keyword)){ 
 				String jwt = header.replace(keyword, "").trim();
 				if(CustomJWToken.isValidJWT(jwt)){
 					this.selectedKeyword = keyword;


### PR DESCRIPTION
Thanks to https://github.com/GanbaruTobi JWT4B now sports improved JWT Check Feedback.

+ Instead of the generic error message "Invalid Signature / wrong / key / claim failed" more detailed information is returned
+ JWT's with one or more failed claims with a valid signature result in the UI element turning yellow


![yellow](https://i.imgur.com/QGOZvFD.png)
![red](https://i.imgur.com/2iqe7Eh.png)

