### PR TITLE
Compability with Pro v2021.2

### DIFF
--- a/src/gui/JWTInterceptTab.java
+++ b/src/gui/JWTInterceptTab.java
@@ -25,6 +25,8 @@ import javax.swing.JSeparator;
 import javax.swing.JTextArea;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.text.JTextComponent;
 
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
 import org.fife.ui.rsyntaxtextarea.Style;
@@ -34,8 +36,8 @@ import org.fife.ui.rsyntaxtextarea.Token;
 import org.fife.ui.rtextarea.RTextScrollPane;
 
 import app.helpers.Config;
-import model.Strings;
 import model.JWTInterceptModel;
+import model.Strings;
 
 public class JWTInterceptTab extends JPanel {
 
@@ -83,7 +85,13 @@ public class JWTInterceptTab extends JPanel {
 		gridBagLayout.rowWeights = new double[]{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, Double.MIN_VALUE};
 		setLayout(gridBagLayout);
 		
+		JTextComponent.removeKeymap("RTextAreaKeymap");
 		jwtArea = new RSyntaxTextArea(20,60);
+		UIManager.put("RSyntaxTextAreaUI.actionMap", null);
+		UIManager.put("RSyntaxTextAreaUI.inputMap", null);
+		UIManager.put("RTextAreaUI.actionMap", null);
+		UIManager.put("RTextAreaUI.inputMap", null);
+		
 		jwtArea.setMinimumSize(new Dimension(300, 300));
 		jwtArea.setColumns(90);
 		SyntaxScheme scheme = jwtArea.getSyntaxScheme();

--- a/src/gui/JWTInterceptTab.java
+++ b/src/gui/JWTInterceptTab.java
@@ -88,13 +88,12 @@ public class JWTInterceptTab extends JPanel {
 		
 		JTextComponent.removeKeymap("RTextAreaKeymap");
 		jwtArea = new RSyntaxTextArea(20,60);
-		jwtArea.setMarginLinePosition(70);
-		jwtArea.setEOLMarkersVisible(true);
-		jwtArea.setWhitespaceVisible(true);
 		UIManager.put("RSyntaxTextAreaUI.actionMap", null);
 		UIManager.put("RSyntaxTextAreaUI.inputMap", null);
 		UIManager.put("RTextAreaUI.actionMap", null);
 		UIManager.put("RTextAreaUI.inputMap", null);
+		jwtArea.setMarginLinePosition(70);
+		jwtArea.setWhitespaceVisible(true);
 		
 		jwtArea.setMinimumSize(new Dimension(300, 300));
 		SyntaxScheme scheme = jwtArea.getSyntaxScheme();
@@ -198,6 +197,7 @@ public class JWTInterceptTab extends JPanel {
 		jwtKeyArea = new JTextArea("");
 		jwtKeyArea.setRows(2);
 		jwtKeyArea.setLineWrap(false);
+		jwtArea.setWhitespaceVisible(true);
 		jwtKeyArea.setEnabled(false);
 
 		GridBagConstraints gbc_keyField = new GridBagConstraints();

--- a/src/gui/JWTInterceptTab.java
+++ b/src/gui/JWTInterceptTab.java
@@ -38,6 +38,7 @@ import org.fife.ui.rtextarea.RTextScrollPane;
 import app.helpers.Config;
 import model.JWTInterceptModel;
 import model.Strings;
+import javax.swing.ScrollPaneConstants;
 
 public class JWTInterceptTab extends JPanel {
 
@@ -79,21 +80,23 @@ public class JWTInterceptTab extends JPanel {
 	
 	private void drawGui() {	
 		GridBagLayout gridBagLayout = new GridBagLayout();
-		gridBagLayout.columnWidths = new int[] {0, 0, 0, 0, 0};
-		gridBagLayout.rowHeights = new int[]{10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-		gridBagLayout.columnWeights = new double[]{0.0, 1.0, 1.0, 0.0, Double.MIN_VALUE};
+		gridBagLayout.columnWidths = new int[] {0, 100, 250, 0, 0};
+		gridBagLayout.rowHeights = new int[]{10, 0, 0, 0, 0, 0, 0, 30, 0, 0, 0, 0, 0, 0, 0};
+		gridBagLayout.columnWeights = new double[]{0.0, 1.0, 0.0, 0.0, Double.MIN_VALUE};
 		gridBagLayout.rowWeights = new double[]{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, Double.MIN_VALUE};
 		setLayout(gridBagLayout);
 		
 		JTextComponent.removeKeymap("RTextAreaKeymap");
 		jwtArea = new RSyntaxTextArea(20,60);
+		jwtArea.setMarginLinePosition(70);
+		jwtArea.setEOLMarkersVisible(true);
+		jwtArea.setWhitespaceVisible(true);
 		UIManager.put("RSyntaxTextAreaUI.actionMap", null);
 		UIManager.put("RSyntaxTextAreaUI.inputMap", null);
 		UIManager.put("RTextAreaUI.actionMap", null);
 		UIManager.put("RTextAreaUI.inputMap", null);
 		
 		jwtArea.setMinimumSize(new Dimension(300, 300));
-		jwtArea.setColumns(90);
 		SyntaxScheme scheme = jwtArea.getSyntaxScheme();
 		Style style = new Style();
 		style.foreground = new Color(222,133,10);
@@ -105,10 +108,11 @@ public class JWTInterceptTab extends JPanel {
 		jwtArea.setEditable(true);
 		jwtArea.setPopupMenu(new JPopupMenu()); 
 		RTextScrollPane sp = new RTextScrollPane(jwtArea);
+		sp.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
 		sp.setLineNumbersEnabled(false);
 		
 		GridBagConstraints gbc_jwtArea = new GridBagConstraints();
-		gbc_jwtArea.gridheight = 7;
+		gbc_jwtArea.gridheight = 12;
 		gbc_jwtArea.gridwidth = 1;
 		gbc_jwtArea.insets = new Insets(0, 0, 5, 5);
 		gbc_jwtArea.fill = GridBagConstraints.BOTH;
@@ -192,22 +196,19 @@ public class JWTInterceptTab extends JPanel {
 		add(lblSecretKey, gbc_lblSecretKey);
 		
 		jwtKeyArea = new JTextArea("");
+		jwtKeyArea.setRows(2);
+		jwtKeyArea.setLineWrap(false);
 		jwtKeyArea.setEnabled(false);
 
 		GridBagConstraints gbc_keyField = new GridBagConstraints();
-		gbc_keyField.anchor = GridBagConstraints.NORTH;
 		gbc_keyField.insets = new Insets(0, 0, 5, 5);
 		gbc_keyField.fill = GridBagConstraints.HORIZONTAL;
 		gbc_keyField.gridx = 2;
 		gbc_keyField.gridy = 7;
-		jwtKeyArea.setRows(5);
 		
         JScrollPane jp = new JScrollPane(jwtKeyArea);
-		
+        jp.setMinimumSize(new Dimension(100, 70));
 		add(jp, gbc_keyField);
-		jwtKeyArea.setColumns(2);
-		jwtKeyArea.setRows(2);
-		jwtKeyArea.setLineWrap(false);
 		
 		lblProblem = new JLabel("");
 		GridBagConstraints gbc_lblProblem = new GridBagConstraints();
@@ -234,8 +235,8 @@ public class JWTInterceptTab extends JPanel {
 		
 		noneAttackComboBox = new JComboBox<String>();
 		GridBagConstraints gbc_noneAttackComboBox = new GridBagConstraints();
+		gbc_noneAttackComboBox.anchor = GridBagConstraints.WEST;
 		gbc_noneAttackComboBox.insets = new Insets(0, 0, 5, 5);
-		gbc_noneAttackComboBox.fill = GridBagConstraints.HORIZONTAL;
 		gbc_noneAttackComboBox.gridx = 2;
 		gbc_noneAttackComboBox.gridy = 10;
 		add(noneAttackComboBox, gbc_noneAttackComboBox);

--- a/src/gui/JWTSuiteTab.java
+++ b/src/gui/JWTSuiteTab.java
@@ -18,7 +18,9 @@ import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JTextArea;
 import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 import javax.swing.event.DocumentListener;
+import javax.swing.text.JTextComponent;
 
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
 import org.fife.ui.rsyntaxtextarea.Style;
@@ -196,8 +198,14 @@ public class JWTSuiteTab extends JPanel {
 		gbc_jwtOuputField.fill = GridBagConstraints.BOTH;
 		gbc_jwtOuputField.gridx = 1;
 		gbc_jwtOuputField.gridy = 9;
-
+		
+		JTextComponent.removeKeymap("RTextAreaKeymap");
 		jwtOuputField = new RSyntaxTextArea();
+		UIManager.put("RSyntaxTextAreaUI.actionMap", null);
+		UIManager.put("RSyntaxTextAreaUI.inputMap", null);
+		UIManager.put("RTextAreaUI.actionMap", null);
+		UIManager.put("RTextAreaUI.inputMap", null);
+		
 		SyntaxScheme scheme = jwtOuputField.getSyntaxScheme();
 		Style style = new Style();
 		style.foreground = new Color(222, 133, 10);

--- a/src/gui/JWTSuiteTab.java
+++ b/src/gui/JWTSuiteTab.java
@@ -154,6 +154,7 @@ public class JWTSuiteTab extends JPanel {
 		add(configButton, gbc_configButton);
 
 		jwtInputField = new JTextArea();
+		jwtInputField.setBorder(UIManager.getLookAndFeel().getDefaults().getBorder("TextField.border"));
 		jwtInputField.setRows(2);
 		jwtInputField.setLineWrap(true);
 		jwtInputField.setWrapStyleWord(true);
@@ -175,6 +176,7 @@ public class JWTSuiteTab extends JPanel {
 		add(lblEnterSecret, gbc_lblEnterSecret);
 
 		jwtKeyArea = new JTextArea();
+		jwtKeyArea.setBorder(UIManager.getLookAndFeel().getDefaults().getBorder("TextField.border"));
 		GridBagConstraints gbc_jwtKeyField = new GridBagConstraints();
 		gbc_jwtKeyField.insets = new Insets(0, 0, 5, 5);
 		gbc_jwtKeyField.fill = GridBagConstraints.HORIZONTAL;
@@ -205,6 +207,7 @@ public class JWTSuiteTab extends JPanel {
 		UIManager.put("RSyntaxTextAreaUI.inputMap", null);
 		UIManager.put("RTextAreaUI.actionMap", null);
 		UIManager.put("RTextAreaUI.inputMap", null);
+		jwtOuputField.setWhitespaceVisible(true);
 		
 		SyntaxScheme scheme = jwtOuputField.getSyntaxScheme();
 		Style style = new Style();

--- a/src/gui/JWTViewTab.java
+++ b/src/gui/JWTViewTab.java
@@ -14,7 +14,9 @@ import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JTextArea;
 import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 import javax.swing.event.DocumentListener;
+import javax.swing.text.JTextComponent;
 
 import model.JWTTabModel;
 
@@ -67,7 +69,13 @@ public class JWTViewTab extends JPanel{
 		gbc_inputLabel1.gridy = 1;
 		add(keyLabel, gbc_inputLabel1);
 
+		JTextComponent.removeKeymap("RTextAreaKeymap");
 		jwtKeyArea = new JTextArea();
+		UIManager.put("RSyntaxTextAreaUI.actionMap", null);
+		UIManager.put("RSyntaxTextAreaUI.inputMap", null);
+		UIManager.put("RTextAreaUI.actionMap", null);
+		UIManager.put("RTextAreaUI.inputMap", null);
+
 		GridBagConstraints gbc_inputField1 = new GridBagConstraints();
 		gbc_inputField1.insets = new Insets(0, 0, 5, 5);
 		gbc_inputField1.fill = GridBagConstraints.HORIZONTAL;
@@ -133,6 +141,7 @@ public class JWTViewTab extends JPanel{
 		gbc_outputfield.gridx = 1;
 		gbc_outputfield.gridy = 6;
 		add(sp, gbc_outputfield);
+		
 	}
 	
 

--- a/src/gui/JWTViewTab.java
+++ b/src/gui/JWTViewTab.java
@@ -7,6 +7,8 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.SystemColor;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 
 import javax.swing.JButton;
 import javax.swing.JLabel;
@@ -18,8 +20,6 @@ import javax.swing.UIManager;
 import javax.swing.event.DocumentListener;
 import javax.swing.text.JTextComponent;
 
-import model.JWTTabModel;
-
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
 import org.fife.ui.rsyntaxtextarea.Style;
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants;
@@ -28,6 +28,7 @@ import org.fife.ui.rsyntaxtextarea.Token;
 import org.fife.ui.rtextarea.RTextScrollPane;
 
 import app.algorithm.AlgorithmType;
+import model.JWTTabModel;
 
 public class JWTViewTab extends JPanel{
 
@@ -69,13 +70,8 @@ public class JWTViewTab extends JPanel{
 		gbc_inputLabel1.gridy = 1;
 		add(keyLabel, gbc_inputLabel1);
 
-		JTextComponent.removeKeymap("RTextAreaKeymap");
 		jwtKeyArea = new JTextArea();
-		UIManager.put("RSyntaxTextAreaUI.actionMap", null);
-		UIManager.put("RSyntaxTextAreaUI.inputMap", null);
-		UIManager.put("RTextAreaUI.actionMap", null);
-		UIManager.put("RTextAreaUI.inputMap", null);
-
+		jwtKeyArea.setBorder(UIManager.getLookAndFeel().getDefaults().getBorder("TextField.border"));
 		GridBagConstraints gbc_inputField1 = new GridBagConstraints();
 		gbc_inputField1.insets = new Insets(0, 0, 5, 5);
 		gbc_inputField1.fill = GridBagConstraints.HORIZONTAL;
@@ -85,6 +81,11 @@ public class JWTViewTab extends JPanel{
 		jwtKeyArea.setColumns(10);
 		
 		verificationIndicator = new JButton("");
+		verificationIndicator.setText("No secret provided");
+		verificationIndicator.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+			}
+		});
 		Dimension preferredSize = new Dimension(400, 30);
 		verificationIndicator.setPreferredSize(preferredSize);
 		GridBagConstraints gbc_validIndicator = new GridBagConstraints();
@@ -92,8 +93,15 @@ public class JWTViewTab extends JPanel{
 		gbc_validIndicator.gridx = 1;
 		gbc_validIndicator.gridy = 4;
 		add(verificationIndicator, gbc_validIndicator);
-
+		
+		JTextComponent.removeKeymap("RTextAreaKeymap");
 		outputField = new RSyntaxTextArea();
+		UIManager.put("RSyntaxTextAreaUI.actionMap", null);
+		UIManager.put("RSyntaxTextAreaUI.inputMap", null);
+		UIManager.put("RTextAreaUI.actionMap", null);
+		UIManager.put("RTextAreaUI.inputMap", null);
+		
+		outputField.setWhitespaceVisible(true);
 		SyntaxScheme scheme = outputField.getSyntaxScheme();
 		Style style = new Style();
 		style.foreground = new Color(222,133,10);
@@ -190,7 +198,12 @@ public class JWTViewTab extends JPanel{
 					verificationIndicator.setBackground(jwtTM.getVerificationColor());
 				}
 				if(!jwtTM.getVerificationLabel().equals(verificationIndicator.getText())){
-					verificationIndicator.setText(jwtTM.getVerificationLabel());
+					if(jwtTM.getVerificationLabel().equals("")) {
+						verificationIndicator.setText("No secret provided");
+					}else {
+						verificationIndicator.setText(jwtTM.getVerificationLabel());						
+					}
+					
 				}
 				if(algorithmType.equals(AlgorithmType.symmetric)){
 					keyLabel.setText("Secret");


### PR DESCRIPTION
Fixing a issue with rsyntaxtextarea and the new burp versions, where users of the Pro version couldn't type anything anymore into the JWT text areas.
This also fixes old and community versions, that couldn't type after installation of the plugin (a restart of burp helped there).
More infos on the fix -> https://github.com/bobbylight/RSyntaxTextArea/issues/269#issuecomment-777656247 


Furthermore, the UI was tweaked and improved.