### PR TITLE
2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Note: If resetEditor is set to false, all options such as the re-singing and alg
 ## Building your own version (with Eclipse)
 1. Clone repository and create new Eclipse Java Project
 2. Rightclick -> Configure -> Convert to Maven Project (downloading all required libraries)
-3. Open Burp -> Extender -> APIs -> Save interface files -> Copy all files to JWT4B\src\burp
+3. Open Burp -> Extensions -> APIs -> Save interface files -> Copy all files to JWT4B\src\burp
 4. Export runnable fat JAR including libraries
 5. Load the JAR in Burp through the Extender Tab -> Extensions -> Add (Good to know: CTRL+Click on a extension to reload it)
 

--- a/pom.xml
+++ b/pom.xml
@@ -75,10 +75,10 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.1</version>
+				<version>3.8.1</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<source>20</source>
+					<target>20</target>
 					<descriptorRefs>
 						<descriptorRef>jar-with-dependencies</descriptorRef>
 					</descriptorRefs>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.11.3</version>
+			<version>2.12.7.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.eclipsesource.minimal-json</groupId>

--- a/src/gui/JWTInterceptTab.java
+++ b/src/gui/JWTInterceptTab.java
@@ -47,7 +47,7 @@ import model.Strings;
 public class JWTInterceptTab extends JPanel {
 
   private static final long serialVersionUID = 1L;
-  public static final String HTML_DISABLE = "html.disable";
+  private static final String HTML_DISABLE = "html.disable";
   private final JWTInterceptModel jwtIM;
   private final RSyntaxTextAreaFactory rSyntaxTextAreaFactory;
   private JRadioButton rdbtnRecalculateSignature;
@@ -242,6 +242,7 @@ public class JWTInterceptTab extends JPanel {
     actionPanel.add(chkbxCVEAttack, c);
 
     lblCookieFlags = new JLabel("");
+    lblCookieFlags.putClientProperty(HTML_DISABLE, null);
     c.gridy = 12;
     actionPanel.add(lblCookieFlags, c);
 

--- a/src/module-info.java
+++ b/src/module-info.java
@@ -1,0 +1,16 @@
+/**
+ * 
+ */
+/**
+ * 
+ */
+module JWT4B {
+	requires java.jwt;
+	requires org.apache.commons.codec;
+	requires minimal.json;
+	requires com.fasterxml.jackson.core;
+	requires com.fasterxml.jackson.databind;
+	requires java.desktop;
+	requires commons.lang;
+	requires rsyntaxtextarea;
+}


### PR DESCRIPTION
Fixed: Cookie data HTML not rendered within Intercept tab
HTML rendering has been disabled within Burp extensions and is re-enabled.
Thanks https://github.com/DolphFlynn for the PR

-- 
https://github.com/ozzi-/JWT4B/releases/tag/2.4